### PR TITLE
Move from rocket to pure hyper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2018"
 build = "build.rs"
 
 [dependencies]
-rocket = "0.4.1"
+hyper = "0.12.33"
+futures = "0.1.28"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,63 @@
-#![feature(proc_macro_hygiene, decl_macro)]
 
-use rocket::response::content;
+extern crate hyper;
+extern crate futures;
 
-#[macro_use]
-extern crate rocket;
+// based on https://github.com/hyperium/hyper/blob/0.12.x/examples/echo.rs
+use hyper::rt::Future;
+use futures::future;
+use hyper::service::service_fn;
+use hyper::{Body, Method, Request, Response, Server, StatusCode};
 
-#[get("/")]
-fn index() -> content::Html<String> {
-    content::Html(include_str!("../ui/dist/index.html").to_string())
+
+type BoxFut = Box<dyn Future<Item = Response<Body>, Error = hyper::Error> + Send>;
+
+
+fn index(_req: Request<Body>) -> Body {
+    Body::from(include_str!("../ui/dist/index.html").to_string())
 }
 
-#[get("/bundle.js")]
-fn bundle() -> content::Html<String> {
-    content::Html(include_str!("../ui/dist/bundle.js").to_string())
+fn bundle(_req: Request<Body>) -> Body {
+    Body::from(include_str!("../ui/dist/bundle.js").to_string())
+}
+
+fn router(req: Request<Body>) -> BoxFut {
+    let mut response = Response::new(Body::empty());
+
+    match (req.method(), req.uri().path()) {
+        (&Method::GET, "/") => {
+            *response.body_mut() = index(req);
+        }
+
+        (&Method::GET, "/bundle.js") => {
+            *response.body_mut() = bundle(req);
+        }
+
+        // The 404 Not Found route...
+        _ => {
+            *response.status_mut() = StatusCode::NOT_FOUND;
+        }
+    };
+
+    Box::new(future::ok(response))
 }
 
 fn main() {
-    rocket::ignite().mount("/", routes![index, bundle]).launch();
+
+    // This is our socket address...
+    let addr = ([127, 0, 0, 1], 3000).into();
+
+    // A `Service` is needed for every connection, so this
+    // creates one
+    let new_svc = || {
+        service_fn(router)
+    };
+
+    let server = Server::bind(&addr)
+        .serve(new_svc)
+        .map_err(|e| eprintln!("server error: {}", e));
+
+    println!("Listening on http://{}", addr);
+
+    hyper::rt::run(server);
+
 }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -2844,7 +2844,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2865,12 +2866,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2885,17 +2888,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3012,7 +3018,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3024,6 +3031,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3038,6 +3046,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3045,12 +3054,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3069,6 +3080,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3149,7 +3161,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3161,6 +3174,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3246,7 +3260,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3282,6 +3297,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3301,6 +3317,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3344,12 +3361,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
Hyper requires futures. This is also operating in a scenario where
futures are in std -- this requires rust 1.39